### PR TITLE
Bc bump customer v3

### DIFF
--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -209,7 +209,8 @@ class Bigcommerce():
                 'date_created'
             ],
             'sub_resources': 0,
-            'exclude_paths': []
+            'exclude_paths': [],
+            'include_extra_paths': ['addresses']
         },
         'products': {
             'version': 3,

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -209,9 +209,7 @@ class Bigcommerce():
                 'date_created'
             ],
             'sub_resources': 0,
-            'exclude_paths': [
-                ('addresses',)
-            ]
+            'exclude_paths': []
         },
         'products': {
             'version': 3,

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -327,10 +327,6 @@ class Bigcommerce():
             concurrent.futures.Future
         """
         future = self.session.get(url, params=params, headers=self.headers)
-        print('LINE 330')
-        print(future.result().request.url)
-        print('XXXXXX')
-        print(future.result().json())
 
         if resolve:
             return future.result()
@@ -401,6 +397,8 @@ class Bigcommerce():
             data = r.data if version == 2 else r.data.get('data', [])
             # unpack nested resources for entire page of results
             data = unpack_resources(data)
+            print('XXXXXX - data - XXXXXX')
+            print(data)
 
             try:
                 for row in data:

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -329,6 +329,8 @@ class Bigcommerce():
         future = self.session.get(url, params=params, headers=self.headers)
         print('LINE 330')
         print(future.result().request.url)
+        print('XXXXXX')
+        print(future.result().json())
 
         if resolve:
             return future.result()

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -202,7 +202,7 @@ class Bigcommerce():
             ]
         },
         'customers': {
-            'version': 2,
+            'version': 3,
             'path': 'customers',
             'transform_date_fields': [
                 'date_modified',

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -327,6 +327,8 @@ class Bigcommerce():
             concurrent.futures.Future
         """
         future = self.session.get(url, params=params, headers=self.headers)
+        print('LINE 330')
+        print(future.result().request.url)
 
         if resolve:
             return future.result()

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -397,8 +397,6 @@ class Bigcommerce():
             data = r.data if version == 2 else r.data.get('data', [])
             # unpack nested resources for entire page of results
             data = unpack_resources(data)
-            print('XXXXXX - data - XXXXXX')
-            print(data)
 
             try:
                 for row in data:

--- a/tap_bigcommerce/client.py
+++ b/tap_bigcommerce/client.py
@@ -120,8 +120,8 @@ class BigCommerce(Client):
 
         for start, end in self.iterdates(bookmark):
             for customer in self.api.resource('customers', {
-                    'min_date_modified': start.isoformat(),
-                    'max_date_modified': end.isoformat()
+                    'date_modified:min': start.isoformat(),
+                    'date_modified:max': end.isoformat()
             }):
                 yield customer
 

--- a/tap_bigcommerce/client.py
+++ b/tap_bigcommerce/client.py
@@ -121,7 +121,8 @@ class BigCommerce(Client):
         for start, end in self.iterdates(bookmark):
             for customer in self.api.resource('customers', {
                     'date_modified:min': start.isoformat(),
-                    'date_modified:max': end.isoformat()
+                    'date_modified:max': end.isoformat(),
+                    'include': ','.join(self.api.endpoints.get('customers').get('include_extra_paths'))
             }):
                 yield customer
 

--- a/tap_bigcommerce/client.py
+++ b/tap_bigcommerce/client.py
@@ -124,8 +124,6 @@ class BigCommerce(Client):
                     'date_modified:max': end.isoformat(),
                     'include': ','.join(self.api.endpoints.get('customers').get('include_extra_paths'))
             }):
-                print('XXXXX - Customer - XXXXXX')
-                print(customer)
                 yield customer
 
     def coupons(self):

--- a/tap_bigcommerce/client.py
+++ b/tap_bigcommerce/client.py
@@ -124,6 +124,8 @@ class BigCommerce(Client):
                     'date_modified:max': end.isoformat(),
                     'include': ','.join(self.api.endpoints.get('customers').get('include_extra_paths'))
             }):
+                print('XXXXX - Customer - XXXXXX')
+                print(customer)
                 yield customer
 
     def coupons(self):

--- a/tap_bigcommerce/schemas/customers.json
+++ b/tap_bigcommerce/schemas/customers.json
@@ -6,6 +6,57 @@
     "id": {
       "$ref": "type-integer.json"
     },
+    "addresses": {
+      "type": ["array","null"],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "address1": {
+            "$ref": "type-string.json"
+          },
+          "address2": {
+            "$ref": "type-string.json"
+          },
+          "address_type": {
+            "$ref": "type-string.json"
+          },
+          "city": {
+            "$ref": "type-string.json"
+          },
+          "company": {
+            "$ref": "type-string.json"
+          },
+          "country": {
+            "$ref": "type-string.json"
+          },
+          "country_code": {
+            "$ref": "type-string.json"
+          },
+          "customer_id": {
+            "$ref": "type-integer.json"
+          },
+          "first_name": {
+            "$ref": "type-string.json"
+          },
+          "id": {
+            "$ref": "type-integer.json"
+          },
+          "last_name": {
+            "$ref": "type-string.json"
+          },
+          "phone": {
+            "$ref": "type-string.json"
+          },
+          "postal_code": {
+            "$ref": "type-string.json"
+          },
+          "state_or_province": {
+            "$ref": "type-string.json"
+          }
+        }
+      }
+    },
     "company": {
       "$ref": "type-string.json"
     },


### PR DESCRIPTION
## Context: 
* Singer pipeline currently uses v2 of the customer endpoint which will soon be deprecated 

## Changes:
* Updated customer stream to v3
* added `include` field to class variable `endpoints` so that we can use the include parameter to get customer address information from the customer endpoint