### PR TITLE
version bump to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.1.0
+    * Adds `Customersv3` and `AttributeValues` streams [#7](https://github.com/singer-io/tap-chargebee/pull/7)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-bigcommerce",
-    version="1.0.2",
+    version="1.1.0",
     description="Sync data from your BigCommerce Store",
     author="Chris Goddard",
     url="https://github.com/chrisgoddard",


### PR DESCRIPTION
# Description of change
## 1.1.0
 - Adds `Customersv3` and `AttributeValues` streams [#7](https://github.com/singer-io/tap-chargebee/pull/7)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
