### PR TITLE
version bump to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.1.1
+  * Reverts previous version [#10](https://github.com/singer-io/tap-chargebee/pull/10)
 
 ## 1.1.0
-    * Adds `Customersv3` and `AttributeValues` streams [#7](https://github.com/singer-io/tap-chargebee/pull/7)
+  * Adds `Customersv3` and `AttributeValues` streams [#7](https://github.com/singer-io/tap-chargebee/pull/7)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-bigcommerce",
-    version="1.1.0",
+    version="1.1.1",
     description="Sync data from your BigCommerce Store",
     author="Chris Goddard",
     url="https://github.com/chrisgoddard",


### PR DESCRIPTION
# Description of change
## 1.1.1
  * Reverts previous version [#10](https://github.com/singer-io/tap-chargebee/pull/10)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
