### PR TITLE
Changed product.external_id to string

### DIFF
--- a/tap_bigcommerce/schemas/orders.json
+++ b/tap_bigcommerce/schemas/orders.json
@@ -442,7 +442,7 @@
             }
           },
           "external_id": {
-            "$ref": "type-integer.json"
+            "$ref": "type-string.json"
           }
         }
       }

--- a/tap_bigcommerce/schemas/orders.json
+++ b/tap_bigcommerce/schemas/orders.json
@@ -442,7 +442,7 @@
             }
           },
           "external_id": {
-            "$ref": "type-string.json"
+            "type": ["integer", "string", "null"] 
           }
         }
       }


### PR DESCRIPTION
# Description of change
product.external_id is defined as a string in the BigCommerce v2 API documentation. This request is related to issue #14, where external_id's in the BigCommerce source are strings and the insert fails for these orders. 

The BigCommerce API docs which indicate the external_id is a string [(https://developer.bigcommerce.com/api-reference/store-management/orders/orders/createanorder)]

Screenshot of the API doc:
https://share.getcloudapp.com/v1ujPmGe


# Manual QA steps
 Verify string external_ids are being passed through the Tap
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
