### PR TITLE
changes to line 430 to accept int and string

### DIFF
--- a/tap_bigcommerce/schemas/orders.json
+++ b/tap_bigcommerce/schemas/orders.json
@@ -427,7 +427,7 @@
                   "$ref": "type-string.json"
                 },
                 "value": {
-                  "$ref": "type-number.json"
+                  "type": ["integer", "string", "null"]
                 },
                 "type": {
                   "$ref": "type-string.json"


### PR DESCRIPTION
# Description of change
product.product_options.value is defined as a string in the BigCommerce v2 API documentation. This request is related to issue [#17 ](https://github.com/singer-io/tap-bigcommerce/issues/17) where value's in the BigCommerce source are strings and the insert fails for these orders.

The BigCommerce API docs which indicate the product_options.value is a string [(https://developer.bigcommerce.com/api-reference/3b4dfef625708-list-order-products)]

Screenshot for BigCommerce API doc
https://drive.google.com/file/d/1G4Y9JX7bcdVsbml-MzB8hHrUEx_NpZPL/view?usp=sharing

# Manual QA steps
Verify string and integer product_options.value are being passed through the Tap
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
