### PR TITLE
Exclude unauthorized streams in catalog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,184 @@
+﻿# Instructions for Building a Singer Tap/Target
+
+This document provides guidance for implementing a high-quality Singer Tap (or Target) in compliance with the Singer specification and community best practices. Use it in conjunction with GitHub Copilot or your preferred IDE.
+
+---
+
+## 1. Rate Limiting
+
+- Respect API rate limits (e.g., daily quotas or per-second limits).
+- For short-term rate limits, detect HTTP 429 or similar errors and implement retries with sleep/delay.
+- Use Singer’s built-in rate-limiting utilities where available.
+
+
+## 2. Memory Efficiency
+
+- Minimize RAM usage by streaming data.
+Example: Use generators or iterators instead of loading entire datasets into memory.
+
+
+## 3. Consistent Date Handling
+
+- Use RFC 3339 format (including time zone offset). UTC (Z) is preferred.
+Examples:
+Good: 2017-01-01T00:00:00Z, 2017-01-01T00:00:00-05:00
+Bad: 2017-01-01 00:00:00
+Use pytz for timezone-aware conversions.
+
+
+## 4. Logging & Exception Handling
+
+- Log every API request (URL + parameters), omitting sensitive info (e.g., API keys).
+- Log progress updates (e.g., “Starting stream X”).
+- On API errors, log status code and response body.
+
+For fatal errors:
+- Log at CRITICAL or FATAL level.
+- Exit with non-zero status.
+- Omit stack trace for known, user-triggered conditions.
+- Include full trace for unexpected exceptions.
+- For recoverable errors, implement retries with exponential backoff (e.g., using the backoff library).
+
+
+## 5. Module Structure
+
+- Organize code into a proper Python module (directory with __init__.py), not a single script file.
+
+
+## 6. Schema Management
+
+- For static schemas, store them as .json files in a schemas/ directory—not as inline Python dicts.
+Prefer explicit schemas:
+- Avoid additionalProperties: true or vague typing.
+- Use clear field names and types.
+- Set additionalProperties: false when schemas must be strict.
+- Be cautious when tightening schemas in new versions—it may require a major version bump per semantic versioning.
+
+
+## 7. JSON Schema Guidelines
+
+- All files under schemas/*.json must follow the JSON Schema standard.
+- Any fields named created_time, modified_time, ending in _time or ending in _date must use the date-time format.
+- Any fields look like date-time field, give suggestion to validate the fields should have date-time format.
+- Avoid using additionalProperties at the root level. It's allowed in nested fields only.
+
+Example:
+{
+  "type": "object",
+  "properties": {
+    "created_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_access_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}
+
+
+## 8. Validating Bookmarking
+
+We use the singer.bookmarks module to read from and write to the bookmark state file.
+To ensure correctness, always validate the structure of the bookmark state before processing or committing any changes.
+- In abstract.py, we use get_bookmark() and write_bookmark() to manage bookmarks for streams.
+- The write_bookmark() function overrides the one from the singer module to apply custom behavior.
+- Always confirm that the state structure matches the expected format before writing.
+
+Format Example:
+{
+  "bookmarks": {
+    "stream_name": {
+      "replication_key": "2024-01-01T00:00:00Z"
+    }
+  }
+}
+
+
+Optional validation function:
+def is_valid_bookmark_state(state):
+    return isinstance(state, dict) and \
+           "bookmarks" in state and \
+           isinstance(state["bookmarks"], dict)
+
+
+## 9. Code Quality
+
+- Use pylint and aim for zero error-level messages.
+- CI pipelines (e.g., CircleCI) should enforce linting.
+- Fix or explicitly disable warnings when appropriate.
+
+
+## 10. Loop Safety
+
+- **Avoid `while True` loops.** Use explicit conditions instead (e.g., `while has_more_pages`).
+- Every loop must have a clear exit condition that will eventually be satisfied.
+- For pagination loops, ensure there's a termination condition (e.g., no next page, empty results, max iterations).
+- Add safeguards like maximum iteration counts or timeouts for loops that depend on external API responses.
+
+Good example (explicit condition):
+```python
+max_pages = 1000
+current_page = 1
+has_more_pages = True
+
+while has_more_pages and current_page <= max_pages:
+    response = fetch_page(current_page)
+    if not response or not response.get('data'):
+        has_more_pages = False
+        break
+
+    process_data(response['data'])
+
+    next_page = response.get('next_page')
+    if not next_page:
+        has_more_pages = False
+    else:
+        current_page += 1
+```
+
+Bad example (using while True):
+```python
+while True:
+    response = fetch_page()
+    if not response:
+        break  # Avoid this pattern
+    process_data(response)
+```
+
+
+## 11. Record Completeness
+
+- **Never skip records during sync unless absolutely necessary.**
+- If a record encounters an error during transformation or validation, log the error with full context but do not silently skip it.
+- Only skip records if:
+  - They fail schema validation and cannot be processed (log as WARNING or ERROR).
+  - They are explicitly filtered by business logic (e.g., replication key filtering).
+- **Never use `continue` to skip records on errors without logging.**
+
+Good example (log and handle errors):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+        counter.increment()
+    except Exception as e:
+        LOGGER.error(f"Failed to transform record {record.get('id')}: {e}")
+        # Re-raise or handle based on severity
+        raise
+```
+
+Bad example (silently skipping records):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+    except Exception:
+        continue  # Silently skips - BAD!
+```
+
+- For incremental streams, ensure bookmark filtering logic is correct to avoid data loss.
+- If a record must be skipped, document why in the code and log it clearly.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-﻿# Instructions for Building a Singer Tap/Target
+# Instructions for Building a Singer Tap/Target
 
 This document provides guidance for implementing a high-quality Singer Tap (or Target) in compliance with the Singer specification and community best practices. Use it in conjunction with GitHub Copilot or your preferred IDE.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0
+  * Exclude 403-forbidden streams from discovery instead of failing [#25](https://github.com/singer-io/tap-bigcommerce/pull/25)
+  * Adds unit tests for discovery access checks.
+
 ## 1.2.0
   * Updated python version 3.12 [#24](https://github.com/singer-io/tap-bigcommerce/pull/24)
   * Upgraded dependancies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0
   * Exclude 403-forbidden streams from discovery instead of failing [#25](https://github.com/singer-io/tap-bigcommerce/pull/25)
   * Adds unit tests for discovery access checks.
+  * Upgrade `requests` from 2.33.1 to 2.34.2.
 
 ## 1.2.0
   * Updated python version 3.12 [#24](https://github.com/singer-io/tap-bigcommerce/pull/24)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-bigcommerce",
-    version="1.2.0",
+    version="1.3.0",
     description="Sync data from your BigCommerce Store",
     author="Chris Goddard",
     url="https://github.com/chrisgoddard",
@@ -11,13 +11,15 @@ setup(
     py_modules=["tap_bigcommerce"],
     install_requires=[
         "singer-python==6.8.0",
-        "requests==2.33.1",
+        "requests==2.34.2",
         "requests-futures==1.0.2"
     ],
     extras_require={
         'dev': [
             'ipdb',
+            'coverage',
             'pylint',
+            'pytest',
         ]
     },
     entry_points="""

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -289,9 +289,9 @@ class Bigcommerce():
             elif resp.status_code == 429:
                 raise BigCommerceRateLimitException(resp)
             elif resp.status_code == 403:
+                error_detail = resp.text[:200] if resp.text else "No additional details"
                 raise BigCommerceForbiddenError(
-                    "HTTP-error-code: 403, Error: Forbidden — the credentials do not "
-                    "have access to the requested resource."
+                    f"URL: {resp.url}, HTTP-Error-Code: 403, HTTP-Error-Message: {error_detail}"
                 )
             else:
                 raise HTTPError(resp)

--- a/tap_bigcommerce/bigcommerce.py
+++ b/tap_bigcommerce/bigcommerce.py
@@ -167,6 +167,13 @@ class BigCommerceRateLimitException(Exception):
     pass
 
 
+class BigCommerceForbiddenError(Exception):
+    """Raised when the BigCommerce API returns a 403 Forbidden response.
+    Indicates the credentials do not have access to the requested resource.
+    """
+    pass
+
+
 class Bigcommerce():
 
     auth_check_url = "https://api.bigcommerce.com/store"
@@ -281,6 +288,11 @@ class Bigcommerce():
                 resp.data = []
             elif resp.status_code == 429:
                 raise BigCommerceRateLimitException(resp)
+            elif resp.status_code == 403:
+                raise BigCommerceForbiddenError(
+                    "HTTP-error-code: 403, Error: Forbidden — the credentials do not "
+                    "have access to the requested resource."
+                )
             else:
                 raise HTTPError(resp)
         else:

--- a/tap_bigcommerce/discover.py
+++ b/tap_bigcommerce/discover.py
@@ -4,7 +4,7 @@ import singer
 from tap_bigcommerce.streams import STREAMS
 from tap_bigcommerce.bigcommerce import BigCommerceForbiddenError
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger().getChild('tap-bigcommerce')
 
 
 def _apply_access_checks(stream_instances):

--- a/tap_bigcommerce/discover.py
+++ b/tap_bigcommerce/discover.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import singer
 
 from tap_bigcommerce.streams import STREAMS
@@ -8,11 +7,7 @@ from tap_bigcommerce.bigcommerce import BigCommerceForbiddenError
 LOGGER = singer.get_logger()
 
 
-def get_abs_path(path):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
-
-
-def _apply_access_checks(client, stream_instances):
+def _apply_access_checks(stream_instances):
     """
     Probe each stream for read access and return only the accessible ones.
 
@@ -21,16 +16,19 @@ def _apply_access_checks(client, stream_instances):
     streams are accessible, since discovery would produce an empty catalog.
 
     Args:
-        client: BigCommerce client instance.
         stream_instances: list of Stream instances to probe.
 
     Returns:
         list of Stream instances that are accessible.
     """
-    inaccessible_streams = [
-        s.name for s in stream_instances if not s.check_access()
-    ]
-    accessible_streams = [s for s in stream_instances if s.name not in inaccessible_streams]
+    accessible_streams = []
+    inaccessible_streams = []
+
+    for s in stream_instances:
+        if s.check_access():
+            accessible_streams.append(s)
+        else:
+            inaccessible_streams.append(s.name)
 
     if not accessible_streams:
         raise BigCommerceForbiddenError(
@@ -55,7 +53,7 @@ def discover_streams(client):
     returned catalog instead of raising an error, allowing partial discovery.
     """
     stream_instances = [s(client) for s in STREAMS.values()]
-    accessible_instances = _apply_access_checks(client, stream_instances)
+    accessible_instances = _apply_access_checks(stream_instances)
 
     streams = []
     for s in accessible_instances:

--- a/tap_bigcommerce/discover.py
+++ b/tap_bigcommerce/discover.py
@@ -3,17 +3,62 @@ import os
 import singer
 
 from tap_bigcommerce.streams import STREAMS
+from tap_bigcommerce.bigcommerce import BigCommerceForbiddenError
+
+LOGGER = singer.get_logger()
 
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
-def discover_streams(client):
-    streams = []
+def _apply_access_checks(client, stream_instances):
+    """
+    Probe each stream for read access and return only the accessible ones.
 
-    for s in STREAMS.values():
-        s = s(client)
+    Streams whose credentials return HTTP 403 are excluded from the catalog
+    and a warning is logged for each. Raises BigCommerceForbiddenError if no
+    streams are accessible, since discovery would produce an empty catalog.
+
+    Args:
+        client: BigCommerce client instance.
+        stream_instances: list of Stream instances to probe.
+
+    Returns:
+        list of Stream instances that are accessible.
+    """
+    inaccessible_streams = [
+        s.name for s in stream_instances if not s.check_access()
+    ]
+    accessible_streams = [s for s in stream_instances if s.name not in inaccessible_streams]
+
+    if not accessible_streams:
+        raise BigCommerceForbiddenError(
+            "403 Forbidden: No read access to supported streams. Data collection cannot start."
+        )
+
+    if inaccessible_streams:
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following "
+            "stream(s): %s. These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+    return accessible_streams
+
+
+def discover_streams(client):
+    """
+    Run discovery, probe each stream for access, and return the catalog dict.
+
+    Streams the credentials cannot access (HTTP 403) are excluded from the
+    returned catalog instead of raising an error, allowing partial discovery.
+    """
+    stream_instances = [s(client) for s in STREAMS.values()]
+    accessible_instances = _apply_access_checks(client, stream_instances)
+
+    streams = []
+    for s in accessible_instances:
         schema = singer.resolve_schema_references(s.load_schema())
         streams.append({
             'stream': s.name,

--- a/tap_bigcommerce/streams.py
+++ b/tap_bigcommerce/streams.py
@@ -136,17 +136,13 @@ class Stream():
         """
         try:
             api = self.client.api
-            endpoint = api.endpoints.get(self.name, {})
-            version = endpoint.get('version', 3)
-            path = endpoint.get('path', self.name)
+            endpoint = api.endpoints[self.name]
+            version = endpoint['version']
+            path = endpoint['path']
             url = api.make_url(version, path)
             api.get(url, {'limit': 1}, resolve=True)
             return True
         except BigCommerceForbiddenError:
-            logger.warning(
-                "Stream '%s' does not have read permission (403), excluding from catalog.",
-                self.name,
-            )
             return False
 
     # The main sync function.

--- a/tap_bigcommerce/streams.py
+++ b/tap_bigcommerce/streams.py
@@ -142,7 +142,12 @@ class Stream():
             url = api.make_url(version, path)
             api.get(url, {'limit': 1}, resolve=True)
             return True
-        except BigCommerceForbiddenError:
+        except BigCommerceForbiddenError as exc:
+            logger.warning(
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message:'%s'",
+                self.name,
+                str(exc),
+            )
             return False
 
     # The main sync function.

--- a/tap_bigcommerce/streams.py
+++ b/tap_bigcommerce/streams.py
@@ -4,6 +4,7 @@ from singer import utils
 import os
 import singer
 import tap_bigcommerce.utilities as tap_utils
+from tap_bigcommerce.bigcommerce import BigCommerceForbiddenError
 
 
 logger = singer.get_logger().getChild('tap-bigcommerce')
@@ -123,6 +124,30 @@ class Stream():
 
     def is_selected(self):
         return self.stream is not None
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+
+        Makes a lightweight single-record GET request to the stream's endpoint.
+        Returns True if the request succeeds; returns False if the API responds
+        with 403 Forbidden, indicating the credentials lack the required permission.
+        Any other exception is re-raised.
+        """
+        try:
+            api = self.client.api
+            endpoint = api.endpoints.get(self.name, {})
+            version = endpoint.get('version', 3)
+            path = endpoint.get('path', self.name)
+            url = api.make_url(version, path)
+            api.get(url, {'limit': 1}, resolve=True)
+            return True
+        except BigCommerceForbiddenError:
+            logger.warning(
+                "Stream '%s' does not have read permission (403), excluding from catalog.",
+                self.name,
+            )
+            return False
 
     # The main sync function.
     def sync(self, state):

--- a/tests/unittests/test_api.py
+++ b/tests/unittests/test_api.py
@@ -356,8 +356,11 @@ class TestBigcommerceResponseHook(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.status_code = 403
         mock_resp.headers = {}
-        with self.assertRaises(BigCommerceForbiddenError):
+        mock_resp.text = '{"title":"Access Denied","status":403}'
+        with self.assertRaises(BigCommerceForbiddenError) as ctx:
             bc._response_hook(mock_resp)
+        self.assertIn('403', str(ctx.exception))
+        self.assertIn(mock_resp.text, str(ctx.exception))
 
 
 class TestBigcommerceUpdateRateLimit(unittest.TestCase):

--- a/tests/unittests/test_api.py
+++ b/tests/unittests/test_api.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime
 from concurrent.futures import Future
 from tap_bigcommerce.bigcommerce import Bigcommerce
-from tap_bigcommerce.bigcommerce import BigCommerceRateLimitException
+from tap_bigcommerce.bigcommerce import BigCommerceRateLimitException, BigCommerceForbiddenError
 from tap_bigcommerce.bigcommerce import filter_excluded_paths
 from tap_bigcommerce.bigcommerce import transform_dates
 from tap_bigcommerce.bigcommerce import unpack_nested_resources
@@ -330,6 +330,33 @@ class TestBigcommerceResponseHook(unittest.TestCase):
         mock_resp.status_code = 429
         mock_resp.headers = {}
         with self.assertRaises(BigCommerceRateLimitException):
+            bc._response_hook(mock_resp)
+
+    @patch('tap_bigcommerce.bigcommerce.FuturesSession')
+    def test_403_raises_forbidden_error(self, MockSession):
+        session = MagicMock()
+        MockSession.return_value = session
+
+        future = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {
+            'X-Rate-Limit-Time-Reset-Ms': '1000',
+            'X-Rate-Limit-Time-Window-Ms': '30000',
+            'X-Rate-Limit-Requests-Left': '100',
+            'X-Rate-Limit-Requests-Quota': '150',
+        }
+        resp.json.return_value = {'time': 12345}
+        future.result.return_value = resp
+        session.get.return_value = future
+
+        bc = Bigcommerce(
+            client_id='test', access_token='test', store_hash='test'
+        )
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.headers = {}
+        with self.assertRaises(BigCommerceForbiddenError):
             bc._response_hook(mock_resp)
 
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for tap_bigcommerce discovery access-check logic.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+from requests.exceptions import HTTPError
+
+from tap_bigcommerce.bigcommerce import BigCommerceForbiddenError, Bigcommerce
+from tap_bigcommerce.discover import _apply_access_checks, discover_streams
+from tap_bigcommerce.streams import STREAMS, Orders, Products, Coupons, Customers
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_stream(name, accessible=True):
+    """Return a MagicMock that mimics a Stream instance."""
+    s = MagicMock()
+    s.name = name
+    s.check_access.return_value = accessible
+    return s
+
+
+def _make_mock_client(forbidden_streams=None):
+    """
+    Return a MagicMock BigCommerce client.
+
+    `forbidden_streams` is a set of stream names whose api.get() will raise
+    BigCommerceForbiddenError; all others succeed.
+    """
+    forbidden_streams = forbidden_streams or set()
+
+    client = MagicMock()
+
+    # Replicate the real endpoints dict so make_url / endpoints lookups work
+    client.api.endpoints = {
+        'orders': {'version': 2, 'path': 'orders'},
+        'products': {'version': 3, 'path': 'catalog/products'},
+        'customers': {'version': 2, 'path': 'customers'},
+        'coupons': {'version': 2, 'path': 'coupons'},
+    }
+
+    # make_url returns a predictable string
+    client.api.make_url.side_effect = lambda version, path: (
+        f"https://api.bigcommerce.com/stores/test/v{version}/{path}"
+    )
+
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _apply_access_checks()
+# ---------------------------------------------------------------------------
+
+class TestApplyAccessChecks(unittest.TestCase):
+
+    def _all_accessible(self):
+        return [_make_mock_stream(name, accessible=True) for name in STREAMS]
+
+    def _with_forbidden(self, *forbidden_names):
+        return [
+            _make_mock_stream(name, accessible=(name not in forbidden_names))
+            for name in STREAMS
+        ]
+
+    # 1. All accessible → all returned
+    def test_all_accessible_returns_all_instances(self):
+        client = MagicMock()
+        instances = self._all_accessible()
+        result = _apply_access_checks(client, instances)
+        self.assertEqual(len(result), len(instances))
+        self.assertEqual({s.name for s in result}, set(STREAMS.keys()))
+
+    # 2. One inaccessible → excluded
+    def test_one_inaccessible_is_excluded(self):
+        client = MagicMock()
+        instances = self._with_forbidden('orders')
+        result = _apply_access_checks(client, instances)
+        result_names = {s.name for s in result}
+        self.assertNotIn('orders', result_names)
+        self.assertEqual(len(result), len(STREAMS) - 1)
+
+    # 3. Multiple inaccessible → all excluded
+    def test_multiple_inaccessible_all_excluded(self):
+        client = MagicMock()
+        instances = self._with_forbidden('orders', 'products')
+        result = _apply_access_checks(client, instances)
+        result_names = {s.name for s in result}
+        self.assertNotIn('orders', result_names)
+        self.assertNotIn('products', result_names)
+        self.assertEqual(len(result), len(STREAMS) - 2)
+
+    # 4. All inaccessible → BigCommerceForbiddenError
+    def test_all_inaccessible_raises_forbidden_error(self):
+        client = MagicMock()
+        instances = [_make_mock_stream(name, accessible=False) for name in STREAMS]
+        with self.assertRaises(BigCommerceForbiddenError):
+            _apply_access_checks(client, instances)
+
+    # 5. Returns only accessible instances (identity check)
+    def test_returns_accessible_instances_in_order(self):
+        client = MagicMock()
+        instances = self._with_forbidden('coupons')
+        result = _apply_access_checks(client, instances)
+        # Accessible instances should be the exact objects (same mock identity)
+        accessible_originals = [s for s in instances if s.name != 'coupons']
+        self.assertEqual(result, accessible_originals)
+
+    # 6. Warning logged for excluded stream
+    def test_warning_logged_for_excluded_stream(self):
+        client = MagicMock()
+        instances = self._with_forbidden('customers')
+        with patch('tap_bigcommerce.discover.LOGGER') as mock_logger:
+            _apply_access_checks(client, instances)
+            mock_logger.warning.assert_called_once()
+            warning_msg = ' '.join(str(a) for a in mock_logger.warning.call_args[0])
+            self.assertIn('customers', warning_msg)
+
+    # 7. No warning when all accessible
+    def test_no_warning_when_all_accessible(self):
+        client = MagicMock()
+        instances = self._all_accessible()
+        with patch('tap_bigcommerce.discover.LOGGER') as mock_logger:
+            _apply_access_checks(client, instances)
+            mock_logger.warning.assert_not_called()
+
+    # Forbidden error message contains useful text
+    def test_forbidden_error_message_mentions_permissions(self):
+        client = MagicMock()
+        instances = [_make_mock_stream(name, accessible=False) for name in STREAMS]
+        with self.assertRaises(BigCommerceForbiddenError) as ctx:
+            _apply_access_checks(client, instances)
+        self.assertIn('403', str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# discover_streams()
+# ---------------------------------------------------------------------------
+
+class TestDiscoverStreams(unittest.TestCase):
+    """discover_streams() must respect access checks and return valid catalog."""
+
+    # 8. All accessible → all 4 streams in result
+    def test_all_accessible_returns_all_streams(self):
+        client = MagicMock()
+        with patch('tap_bigcommerce.discover._apply_access_checks',
+                   side_effect=lambda c, instances: instances):
+            result = discover_streams(client)
+        self.assertEqual(len(result['streams']), 4)
+
+    # 9. Inaccessible stream excluded
+    def test_inaccessible_stream_excluded_from_catalog(self):
+        client = MagicMock()
+
+        def _filter_orders(c, instances):
+            return [s for s in instances if s.name != 'orders']
+
+        with patch('tap_bigcommerce.discover._apply_access_checks', side_effect=_filter_orders):
+            result = discover_streams(client)
+
+        names = {s['stream'] for s in result['streams']}
+        self.assertNotIn('orders', names)
+        self.assertEqual(len(result['streams']), 3)
+
+    # 10. All inaccessible raises BigCommerceForbiddenError
+    def test_all_inaccessible_raises(self):
+        client = MagicMock()
+        with patch('tap_bigcommerce.discover._apply_access_checks',
+                   side_effect=BigCommerceForbiddenError("all forbidden")):
+            with self.assertRaises(BigCommerceForbiddenError):
+                discover_streams(client)
+
+    # 11. Result structure has required keys
+    def test_result_has_required_keys(self):
+        client = MagicMock()
+        with patch('tap_bigcommerce.discover._apply_access_checks',
+                   side_effect=lambda c, instances: instances):
+            result = discover_streams(client)
+        self.assertIn('streams', result)
+        for s in result['streams']:
+            with self.subTest(stream=s['stream']):
+                self.assertIn('stream', s)
+                self.assertIn('tap_stream_id', s)
+                self.assertIn('schema', s)
+                self.assertIn('metadata', s)
+
+    # stream equals tap_stream_id
+    def test_stream_equals_tap_stream_id(self):
+        client = MagicMock()
+        with patch('tap_bigcommerce.discover._apply_access_checks',
+                   side_effect=lambda c, instances: instances):
+            result = discover_streams(client)
+        for s in result['streams']:
+            self.assertEqual(s['stream'], s['tap_stream_id'])
+
+    # _apply_access_checks is called with client and stream instances
+    def test_apply_access_checks_called_with_client(self):
+        client = MagicMock()
+        with patch('tap_bigcommerce.discover._apply_access_checks',
+                   side_effect=lambda c, instances: instances) as mock_check:
+            discover_streams(client)
+        mock_check.assert_called_once()
+        call_client, call_instances = mock_check.call_args[0]
+        self.assertIs(call_client, client)
+        self.assertEqual(len(call_instances), len(STREAMS))
+
+
+# ---------------------------------------------------------------------------
+# Stream.check_access()
+# ---------------------------------------------------------------------------
+
+class TestStreamCheckAccess(unittest.TestCase):
+    """Stream.check_access() must probe the API and handle 403 gracefully."""
+
+    def _make_stream_instance(self, stream_cls, forbidden=False, error=None):
+        """Create a stream instance with a mock client."""
+        client = MagicMock()
+        client.api.endpoints = {
+            'orders': {'version': 2, 'path': 'orders'},
+            'products': {'version': 3, 'path': 'catalog/products'},
+            'customers': {'version': 2, 'path': 'customers'},
+            'coupons': {'version': 2, 'path': 'coupons'},
+        }
+        client.api.make_url.side_effect = lambda v, p: f"https://api.test/v{v}/{p}"
+
+        if forbidden:
+            client.api.get.side_effect = BigCommerceForbiddenError("403")
+        elif error:
+            client.api.get.side_effect = error
+        else:
+            client.api.get.return_value = MagicMock()
+
+        return stream_cls(client)
+
+    # 12. Returns True when API succeeds
+    def test_returns_true_when_accessible(self):
+        for stream_cls in [Orders, Products, Coupons, Customers]:
+            with self.subTest(stream=stream_cls.name):
+                instance = self._make_stream_instance(stream_cls, forbidden=False)
+                self.assertTrue(instance.check_access())
+
+    # 13. Returns False on BigCommerceForbiddenError
+    def test_returns_false_on_forbidden(self):
+        for stream_cls in [Orders, Products, Coupons, Customers]:
+            with self.subTest(stream=stream_cls.name):
+                instance = self._make_stream_instance(stream_cls, forbidden=True)
+                self.assertFalse(instance.check_access())
+
+    # 14. Re-raises non-forbidden exceptions (ConnectionError)
+    def test_reraises_non_forbidden_exception(self):
+        instance = self._make_stream_instance(
+            Orders, error=ConnectionError("network failure")
+        )
+        with self.assertRaises(ConnectionError):
+            instance.check_access()
+
+    # 14b. Re-raises non-403 HTTPError (e.g. 500) — must not be swallowed
+    def test_reraises_non_403_http_error(self):
+        """A 500 HTTPError from the API must propagate; only 403 is caught."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        http_err = HTTPError(response=mock_response)
+        instance = self._make_stream_instance(Orders, error=http_err)
+        with self.assertRaises(HTTPError):
+            instance.check_access()
+
+    # 15. api.get is called with resolve=True
+    def test_get_called_with_resolve_true(self):
+        instance = self._make_stream_instance(Orders)
+        instance.check_access()
+        # Verify api.get was called and resolve=True was passed
+        instance.client.api.get.assert_called_once()
+        _, kwargs_or_args = instance.client.api.get.call_args[0], instance.client.api.get.call_args
+        # resolve=True can be positional or keyword
+        call_args = instance.client.api.get.call_args
+        # positional: get(url, params, resolve)
+        pos_args = call_args[0]
+        kw_args = call_args[1]
+        resolve_value = pos_args[2] if len(pos_args) > 2 else kw_args.get('resolve')
+        self.assertTrue(resolve_value)
+
+    # warning logged on forbidden
+    def test_warning_logged_on_forbidden(self):
+        instance = self._make_stream_instance(Orders, forbidden=True)
+        with patch('tap_bigcommerce.streams.logger') as mock_logger:
+            instance.check_access()
+            mock_logger.warning.assert_called_once()
+            msg = ' '.join(str(a) for a in mock_logger.warning.call_args[0])
+            self.assertIn('orders', msg)
+
+    # check_access uses correct endpoint URL
+    def test_uses_correct_endpoint_for_each_stream(self):
+        expected_paths = {
+            'orders': 'orders',
+            'products': 'catalog/products',
+            'customers': 'customers',
+            'coupons': 'coupons',
+        }
+        for stream_cls in [Orders, Products, Coupons, Customers]:
+            with self.subTest(stream=stream_cls.name):
+                instance = self._make_stream_instance(stream_cls)
+                instance.check_access()
+                call_args = instance.client.api.get.call_args[0]
+                url = call_args[0]
+                self.assertIn(expected_paths[stream_cls.name], url)
+
+
+class TestBigCommerceEndpointsCompleteness(unittest.TestCase):
+    """All streams in STREAMS must have a corresponding entry in Bigcommerce.endpoints
+    so that check_access() can build a valid probe URL for every stream."""
+
+    def test_all_streams_have_endpoint_config(self):
+        """Every stream name in STREAMS must appear in Bigcommerce.endpoints."""
+        for stream_name in STREAMS:
+            with self.subTest(stream=stream_name):
+                self.assertIn(
+                    stream_name,
+                    Bigcommerce.endpoints,
+                    f"Stream '{stream_name}' is missing from Bigcommerce.endpoints — "
+                    "check_access() would fall back to an incorrect URL.",
+                )
+
+    def test_all_endpoint_configs_have_path(self):
+        """Every stream endpoint config must define a 'path' key for URL construction."""
+        for stream_name in STREAMS:
+            with self.subTest(stream=stream_name):
+                config = Bigcommerce.endpoints.get(stream_name, {})
+                self.assertIn(
+                    'path',
+                    config,
+                    f"Stream '{stream_name}' endpoint config is missing 'path'.",
+                )
+
+    def test_all_endpoint_configs_have_version(self):
+        """Every stream endpoint config must define a 'version' key."""
+        for stream_name in STREAMS:
+            with self.subTest(stream=stream_name):
+                config = Bigcommerce.endpoints.get(stream_name, {})
+                self.assertIn(
+                    'version',
+                    config,
+                    f"Stream '{stream_name}' endpoint config is missing 'version'.",
+                )

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -22,33 +22,6 @@ def _make_mock_stream(name, accessible=True):
     return s
 
 
-def _make_mock_client(forbidden_streams=None):
-    """
-    Return a MagicMock BigCommerce client.
-
-    `forbidden_streams` is a set of stream names whose api.get() will raise
-    BigCommerceForbiddenError; all others succeed.
-    """
-    forbidden_streams = forbidden_streams or set()
-
-    client = MagicMock()
-
-    # Replicate the real endpoints dict so make_url / endpoints lookups work
-    client.api.endpoints = {
-        'orders': {'version': 2, 'path': 'orders'},
-        'products': {'version': 3, 'path': 'catalog/products'},
-        'customers': {'version': 2, 'path': 'customers'},
-        'coupons': {'version': 2, 'path': 'coupons'},
-    }
-
-    # make_url returns a predictable string
-    client.api.make_url.side_effect = lambda version, path: (
-        f"https://api.bigcommerce.com/stores/test/v{version}/{path}"
-    )
-
-    return client
-
-
 # ---------------------------------------------------------------------------
 # _apply_access_checks()
 # ---------------------------------------------------------------------------
@@ -66,26 +39,23 @@ class TestApplyAccessChecks(unittest.TestCase):
 
     # 1. All accessible → all returned
     def test_all_accessible_returns_all_instances(self):
-        client = MagicMock()
         instances = self._all_accessible()
-        result = _apply_access_checks(client, instances)
+        result = _apply_access_checks(instances)
         self.assertEqual(len(result), len(instances))
         self.assertEqual({s.name for s in result}, set(STREAMS.keys()))
 
     # 2. One inaccessible → excluded
     def test_one_inaccessible_is_excluded(self):
-        client = MagicMock()
         instances = self._with_forbidden('orders')
-        result = _apply_access_checks(client, instances)
+        result = _apply_access_checks(instances)
         result_names = {s.name for s in result}
         self.assertNotIn('orders', result_names)
         self.assertEqual(len(result), len(STREAMS) - 1)
 
     # 3. Multiple inaccessible → all excluded
     def test_multiple_inaccessible_all_excluded(self):
-        client = MagicMock()
         instances = self._with_forbidden('orders', 'products')
-        result = _apply_access_checks(client, instances)
+        result = _apply_access_checks(instances)
         result_names = {s.name for s in result}
         self.assertNotIn('orders', result_names)
         self.assertNotIn('products', result_names)
@@ -93,44 +63,39 @@ class TestApplyAccessChecks(unittest.TestCase):
 
     # 4. All inaccessible → BigCommerceForbiddenError
     def test_all_inaccessible_raises_forbidden_error(self):
-        client = MagicMock()
         instances = [_make_mock_stream(name, accessible=False) for name in STREAMS]
         with self.assertRaises(BigCommerceForbiddenError):
-            _apply_access_checks(client, instances)
+            _apply_access_checks(instances)
 
     # 5. Returns only accessible instances (identity check)
     def test_returns_accessible_instances_in_order(self):
-        client = MagicMock()
         instances = self._with_forbidden('coupons')
-        result = _apply_access_checks(client, instances)
+        result = _apply_access_checks(instances)
         # Accessible instances should be the exact objects (same mock identity)
         accessible_originals = [s for s in instances if s.name != 'coupons']
         self.assertEqual(result, accessible_originals)
 
     # 6. Warning logged for excluded stream
     def test_warning_logged_for_excluded_stream(self):
-        client = MagicMock()
         instances = self._with_forbidden('customers')
         with patch('tap_bigcommerce.discover.LOGGER') as mock_logger:
-            _apply_access_checks(client, instances)
+            _apply_access_checks(instances)
             mock_logger.warning.assert_called_once()
             warning_msg = ' '.join(str(a) for a in mock_logger.warning.call_args[0])
             self.assertIn('customers', warning_msg)
 
     # 7. No warning when all accessible
     def test_no_warning_when_all_accessible(self):
-        client = MagicMock()
         instances = self._all_accessible()
         with patch('tap_bigcommerce.discover.LOGGER') as mock_logger:
-            _apply_access_checks(client, instances)
+            _apply_access_checks(instances)
             mock_logger.warning.assert_not_called()
 
     # Forbidden error message contains useful text
     def test_forbidden_error_message_mentions_permissions(self):
-        client = MagicMock()
         instances = [_make_mock_stream(name, accessible=False) for name in STREAMS]
         with self.assertRaises(BigCommerceForbiddenError) as ctx:
-            _apply_access_checks(client, instances)
+            _apply_access_checks(instances)
         self.assertIn('403', str(ctx.exception))
 
 
@@ -145,15 +110,15 @@ class TestDiscoverStreams(unittest.TestCase):
     def test_all_accessible_returns_all_streams(self):
         client = MagicMock()
         with patch('tap_bigcommerce.discover._apply_access_checks',
-                   side_effect=lambda c, instances: instances):
+                   side_effect=lambda instances: instances):
             result = discover_streams(client)
-        self.assertEqual(len(result['streams']), 4)
+        self.assertEqual(len(result['streams']), len(STREAMS))
 
     # 9. Inaccessible stream excluded
     def test_inaccessible_stream_excluded_from_catalog(self):
         client = MagicMock()
 
-        def _filter_orders(c, instances):
+        def _filter_orders(instances):
             return [s for s in instances if s.name != 'orders']
 
         with patch('tap_bigcommerce.discover._apply_access_checks', side_effect=_filter_orders):
@@ -161,7 +126,7 @@ class TestDiscoverStreams(unittest.TestCase):
 
         names = {s['stream'] for s in result['streams']}
         self.assertNotIn('orders', names)
-        self.assertEqual(len(result['streams']), 3)
+        self.assertEqual(len(result['streams']), len(STREAMS) - 1)
 
     # 10. All inaccessible raises BigCommerceForbiddenError
     def test_all_inaccessible_raises(self):
@@ -175,7 +140,7 @@ class TestDiscoverStreams(unittest.TestCase):
     def test_result_has_required_keys(self):
         client = MagicMock()
         with patch('tap_bigcommerce.discover._apply_access_checks',
-                   side_effect=lambda c, instances: instances):
+                   side_effect=lambda instances: instances):
             result = discover_streams(client)
         self.assertIn('streams', result)
         for s in result['streams']:
@@ -189,20 +154,19 @@ class TestDiscoverStreams(unittest.TestCase):
     def test_stream_equals_tap_stream_id(self):
         client = MagicMock()
         with patch('tap_bigcommerce.discover._apply_access_checks',
-                   side_effect=lambda c, instances: instances):
+                   side_effect=lambda instances: instances):
             result = discover_streams(client)
         for s in result['streams']:
             self.assertEqual(s['stream'], s['tap_stream_id'])
 
-    # _apply_access_checks is called with client and stream instances
-    def test_apply_access_checks_called_with_client(self):
+    # _apply_access_checks is called with the stream instances
+    def test_apply_access_checks_called_with_stream_instances(self):
         client = MagicMock()
         with patch('tap_bigcommerce.discover._apply_access_checks',
-                   side_effect=lambda c, instances: instances) as mock_check:
+                   side_effect=lambda instances: instances) as mock_check:
             discover_streams(client)
         mock_check.assert_called_once()
-        call_client, call_instances = mock_check.call_args[0]
-        self.assertIs(call_client, client)
+        (call_instances,) = mock_check.call_args[0]
         self.assertEqual(len(call_instances), len(STREAMS))
 
 
@@ -269,25 +233,21 @@ class TestStreamCheckAccess(unittest.TestCase):
     def test_get_called_with_resolve_true(self):
         instance = self._make_stream_instance(Orders)
         instance.check_access()
-        # Verify api.get was called and resolve=True was passed
-        instance.client.api.get.assert_called_once()
-        _, kwargs_or_args = instance.client.api.get.call_args[0], instance.client.api.get.call_args
-        # resolve=True can be positional or keyword
         call_args = instance.client.api.get.call_args
-        # positional: get(url, params, resolve)
         pos_args = call_args[0]
         kw_args = call_args[1]
         resolve_value = pos_args[2] if len(pos_args) > 2 else kw_args.get('resolve')
         self.assertTrue(resolve_value)
 
-    # warning logged on forbidden
-    def test_warning_logged_on_forbidden(self):
+    # warning is logged at discovery level, not per-stream
+    def test_no_warning_logged_in_check_access_on_forbidden(self):
+        """Per-stream warnings were removed to avoid duplicate logs.
+        The aggregated warning is logged once by _apply_access_checks instead."""
         instance = self._make_stream_instance(Orders, forbidden=True)
         with patch('tap_bigcommerce.streams.logger') as mock_logger:
-            instance.check_access()
-            mock_logger.warning.assert_called_once()
-            msg = ' '.join(str(a) for a in mock_logger.warning.call_args[0])
-            self.assertIn('orders', msg)
+            result = instance.check_access()
+            self.assertFalse(result)
+            mock_logger.warning.assert_not_called()
 
     # check_access uses correct endpoint URL
     def test_uses_correct_endpoint_for_each_stream(self):

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -239,15 +239,20 @@ class TestStreamCheckAccess(unittest.TestCase):
         resolve_value = pos_args[2] if len(pos_args) > 2 else kw_args.get('resolve')
         self.assertTrue(resolve_value)
 
-    # warning is logged at discovery level, not per-stream
-    def test_no_warning_logged_in_check_access_on_forbidden(self):
-        """Per-stream warnings were removed to avoid duplicate logs.
-        The aggregated warning is logged once by _apply_access_checks instead."""
-        instance = self._make_stream_instance(Orders, forbidden=True)
+    # warning is logged by check_access() with the actual error message
+    def test_warning_logged_on_forbidden(self):
+        """check_access() must log a warning that includes the error detail from the exception."""
+        error_detail = "HTTP-error-code: 403, Error: Forbidden"
+        instance = self._make_stream_instance(
+            Orders, error=BigCommerceForbiddenError(error_detail)
+        )
         with patch('tap_bigcommerce.streams.logger') as mock_logger:
             result = instance.check_access()
             self.assertFalse(result)
-            mock_logger.warning.assert_not_called()
+            mock_logger.warning.assert_called_once()
+            msg = ' '.join(str(a) for a in mock_logger.warning.call_args[0])
+            self.assertIn('orders', msg)
+            self.assertIn(error_detail, msg)
 
     # check_access uses correct endpoint URL
     def test_uses_correct_endpoint_for_each_stream(self):
@@ -264,6 +269,19 @@ class TestStreamCheckAccess(unittest.TestCase):
                 call_args = instance.client.api.get.call_args[0]
                 url = call_args[0]
                 self.assertIn(expected_paths[stream_cls.name], url)
+
+    # error message from BigCommerceForbiddenError includes the response body
+    def test_forbidden_error_message_contains_response_text(self):
+        """BigCommerceForbiddenError raised by check_access must carry the API response text."""
+        response_body = '{"title":"Access Denied","status":403}'
+        error_msg = "HTTP-error-code: 403, Error: Forbidden. Response: {}".format(response_body)
+        instance = self._make_stream_instance(
+            Orders, error=BigCommerceForbiddenError(error_msg)
+        )
+        with patch('tap_bigcommerce.streams.logger') as mock_logger:
+            instance.check_access()
+            logged = ' '.join(str(a) for a in mock_logger.warning.call_args[0])
+            self.assertIn(response_body, logged)
 
 
 class TestBigCommerceEndpointsCompleteness(unittest.TestCase):


### PR DESCRIPTION
# Description of change

This PR updates the tap’s discovery flow to **exclude streams that return HTTP 403 (unauthorized)** from the generated Singer catalog, instead of failing discovery entirely. This supports partial extraction for accounts that only have permissions for some BigCommerce resources.

**Changes:**
- Add `BigCommerceForbiddenError` and raise it on 403 responses from the BigCommerce API wrapper.
- Add `Stream.check_access()` and discovery-side filtering (`_apply_access_checks`) to omit unauthorized streams from the catalog.
- Add unit tests covering access-check behavior and bump version/dependencies/documentation accordingly.

[SAC-30994](https://qlik-dev.atlassian.net/browse/SAC-30994)

# Manual QA steps
- [x] Discovery: `tap-bigcommerce --config config.json --discover > catalog.json` — verify catalog contains only accessible streams
- [x] Discovery with blocked credentials — verify `BigCommerceForbiddenError` is raised when no streams are accessible
- [x] Sync: `tap-bigcommerce --config config.json --catalog catalog.json` — verify sync runs normally with an access-filtered catalog
- [x] Unit Tests: `coverage run -m pytest tests/unittests` — all tests pass
- [x] Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
