### PR TITLE
SAC-31140: Update field metadata writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## 1.3.1
+  * Update tap to write metadata for root schema fields [#28](https://github.com/singer-io/tap-bigcommerce/pull/28)
+
 ## 1.3.0
   * Exclude 403-forbidden streams from discovery instead of failing [#25](https://github.com/singer-io/tap-bigcommerce/pull/25)
   * Adds unit tests for discovery access checks.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-bigcommerce",
-    version="1.3.0",
+    version="1.3.1",
     description="Sync data from your BigCommerce Store",
     author="Chris Goddard",
     url="https://github.com/chrisgoddard",

--- a/tap_bigcommerce/streams.py
+++ b/tap_bigcommerce/streams.py
@@ -69,30 +69,11 @@ class Stream():
         return schema_loader.load(self.name)
 
     def load_field_metadata(self, mdata, schema, parent=()):
-        if 'object' in schema.get('type', []):
-            for field_name, field_schema in schema['properties'].items():
-                inclusion = 'automatic' if (
-                    field_name in self.key_properties or
-                    field_name == self.replication_key
-                ) and (
-                    parent == ()
-                ) else 'available'
-
-                breadcrumb = parent + ('properties', field_name)
-
-                mdata = metadata.write(
-                    mdata,
-                    breadcrumb,
-                    'inclusion',
-                    inclusion
-                )
-
-                mdata = self.load_field_metadata(
-                    mdata, field_schema, breadcrumb)
-
-        elif 'array' in schema.get('type', []):
-            mdata = self.load_field_metadata(
-                mdata, schema.get('items', {}), parent + ('items',))
+        for field_name in schema['properties'].keys():
+            if field_name in self.key_properties or field_name == self.replication_key:
+                mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+            else:
+                mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')
 
         return mdata
 

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -300,6 +300,224 @@ class TestLoadMetadata(unittest.TestCase):
 
 
 # ------------------------------------------------------------------ #
+# load_field_metadata
+# ------------------------------------------------------------------ #
+
+class TestLoadFieldMetadata(unittest.TestCase):
+    """
+    Direct unit tests for Stream.load_field_metadata.
+    """
+
+    def _flat_schema(self, *fields):
+        """Return a minimal schema dict whose properties are the given field names."""
+        return {'properties': {f: {'type': 'string'} for f in fields}}
+
+    # ── inclusion correctness ──────────────────────────────────────────────
+
+    def test_key_property_marked_automatic(self):
+        """A field listed in key_properties must receive inclusion='automatic'."""
+        stream = Orders(MockClient)  # key_properties=['id']
+        mdata = metadata.new()
+        result = stream.load_field_metadata(mdata, self._flat_schema('id', 'status'))
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'id')]['inclusion'], 'automatic')
+
+    def test_replication_key_marked_automatic(self):
+        """The replication_key field must receive inclusion='automatic'."""
+        stream = Orders(MockClient)  # replication_key='date_modified'
+        mdata = metadata.new()
+        result = stream.load_field_metadata(
+            mdata, self._flat_schema('id', 'date_modified', 'status')
+        )
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'date_modified')]['inclusion'], 'automatic')
+
+    def test_non_key_field_marked_available(self):
+        """Regular fields (not key / replication) must receive inclusion='available'."""
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        result = stream.load_field_metadata(
+            mdata, self._flat_schema('id', 'date_modified', 'status', 'total_inc_tax')
+        )
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'status')]['inclusion'], 'available')
+        self.assertEqual(mdata_map[('properties', 'total_inc_tax')]['inclusion'], 'available')
+
+    def test_all_properties_receive_inclusion_entry(self):
+        """Every property in the schema must get an inclusion metadata entry."""
+        stream = Orders(MockClient)
+        fields = ['id', 'date_modified', 'status', 'customer_id', 'cart_id']
+        mdata = metadata.new()
+        result = stream.load_field_metadata(mdata, self._flat_schema(*fields))
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        for f in fields:
+            with self.subTest(field=f):
+                self.assertIn(('properties', f), mdata_map,
+                              msg=f"Field '{f}' missing from mdata")
+                self.assertIn('inclusion', mdata_map[('properties', f)])
+
+    def test_full_table_stream_only_key_property_is_automatic(self):
+        """
+        Coupons has replication_key=None.
+        Only key_properties entries should be automatic; everything else available.
+        """
+        stream = Coupons(MockClient)  # key_properties=['id'], replication_key=None
+        self.assertIsNone(stream.replication_key)
+        mdata = metadata.new()
+        result = stream.load_field_metadata(mdata, self._flat_schema('id', 'code', 'amount'))
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'id')]['inclusion'], 'automatic')
+        self.assertEqual(mdata_map[('properties', 'code')]['inclusion'], 'available')
+        self.assertEqual(mdata_map[('properties', 'amount')]['inclusion'], 'available')
+
+    def test_none_replication_key_does_not_accidentally_mark_fields(self):
+        """
+        When replication_key is None, the comparison `field_name == None`
+        must never mark a real string field as automatic.
+        """
+        stream = Coupons(MockClient)
+        mdata = metadata.new()
+        result = stream.load_field_metadata(mdata, self._flat_schema('id', 'code'))
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'code')]['inclusion'], 'available')
+
+    def test_multiple_key_properties_all_automatic(self):
+        """All fields in key_properties must be marked automatic."""
+        stream = Orders(MockClient)
+        stream.key_properties = ['id', 'customer_id']
+        mdata = metadata.new()
+        result = stream.load_field_metadata(
+            mdata, self._flat_schema('id', 'customer_id', 'status')
+        )
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'id')]['inclusion'], 'automatic')
+        self.assertEqual(mdata_map[('properties', 'customer_id')]['inclusion'], 'automatic')
+        self.assertEqual(mdata_map[('properties', 'status')]['inclusion'], 'available')
+
+    # ── behaviour of no recursion ─────────────────────────────────
+
+    def test_nested_object_fields_not_recursed_into(self):
+        """
+        The new implementation does NOT recurse into nested
+        object schemas.  Sub-fields of nested objects must have no breadcrumb
+        entries in mdata.
+        """
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        schema = {
+            'properties': {
+                'id': {'type': 'integer'},
+                'billing_address': {
+                    'type': 'object',
+                    'properties': {
+                        'street_1': {'type': 'string'},
+                        'city':     {'type': 'string'},
+                    },
+                },
+            }
+        }
+        result = stream.load_field_metadata(mdata, schema)
+        mdata_map = metadata.to_map(metadata.to_list(result))
+
+        # Top-level breadcrumbs must exist
+        self.assertIn(('properties', 'id'), mdata_map)
+        self.assertIn(('properties', 'billing_address'), mdata_map)
+
+        # Nested breadcrumbs must NOT exist (new flat behaviour)
+        self.assertNotIn(
+            ('properties', 'billing_address', 'properties', 'street_1'), mdata_map
+        )
+        self.assertNotIn(
+            ('properties', 'billing_address', 'properties', 'city'), mdata_map
+        )
+
+    def test_array_field_not_recursed_into(self):
+        """
+        The new implementation does NOT recurse into array-typed
+        fields; no items-level breadcrumbs must be written.
+        """
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        schema = {
+            'properties': {
+                'id': {'type': 'integer'},
+                'products': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {
+                            'product_id': {'type': 'integer'},
+                        },
+                    },
+                },
+            }
+        }
+        result = stream.load_field_metadata(mdata, schema)
+        mdata_map = metadata.to_map(metadata.to_list(result))
+
+        self.assertIn(('properties', 'products'), mdata_map)
+        # items-level breadcrumb must NOT be present
+        self.assertNotIn(
+            ('properties', 'products', 'items', 'properties', 'product_id'), mdata_map
+        )
+
+    def test_schema_without_type_key_is_handled(self):
+        """
+        The new implementation does not gate on schema['type'], so schemas
+        that omit the type key at root level must not raise an error.
+        """
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        schema = {'properties': {'id': {}, 'status': {}}}  # no 'type' key
+        result = stream.load_field_metadata(mdata, schema)
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        self.assertEqual(mdata_map[('properties', 'id')]['inclusion'], 'automatic')
+        self.assertEqual(mdata_map[('properties', 'status')]['inclusion'], 'available')
+
+    def test_parent_argument_ignored_breadcrumb_always_root(self):
+        """
+        The parent parameter is kept in the signature for compatibility but
+        is no longer used.  Passing a non-empty parent must not change the
+        resulting breadcrumbs — they are always written at root level.
+        """
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        schema = self._flat_schema('id', 'status')
+        result = stream.load_field_metadata(mdata, schema, parent=('properties', 'nested'))
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        # Breadcrumbs are still at root level, not under the provided parent
+        self.assertIn(('properties', 'id'), mdata_map)
+        self.assertIn(('properties', 'status'), mdata_map)
+        self.assertNotIn(('properties', 'nested', 'properties', 'id'), mdata_map)
+
+    # ── return value / mdata preservation ─────────────────────────────────
+
+    def test_returns_updated_mdata(self):
+        """load_field_metadata must return a non-None mdata object."""
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        result = stream.load_field_metadata(mdata, self._flat_schema('id'))
+        self.assertIsNotNone(result)
+        self.assertIn(('properties', 'id'), metadata.to_map(metadata.to_list(result)))
+
+    def test_existing_mdata_entries_are_preserved(self):
+        """
+        Pre-existing entries in the passed mdata must not be removed when new
+        field-level entries are added.
+        """
+        stream = Orders(MockClient)
+        mdata = metadata.new()
+        mdata = metadata.write(mdata, (), 'table-key-properties', ['id'])
+        result = stream.load_field_metadata(mdata, self._flat_schema('id', 'status'))
+        mdata_map = metadata.to_map(metadata.to_list(result))
+        # Pre-existing root entry must still be present
+        self.assertEqual(mdata_map[()]['table-key-properties'], ['id'])
+        # New field entries must also be present
+        self.assertIn(('properties', 'id'), mdata_map)
+        self.assertIn(('properties', 'status'), mdata_map)
+
+
+# ------------------------------------------------------------------ #
 # sync (unit-level: mocked client)
 # ------------------------------------------------------------------ #
 


### PR DESCRIPTION
# Description of change
- Update the field metadata writing
- Tap now uses the top-level keys in schema as per singer standard.
JIRA: https://qlik-dev.atlassian.net/browse/SAC-31440

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
