### PR TITLE
SAC-31563 Updated Schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## 2.0.0
+  * Schema updates for warehouse compatibility: allow `null` for optional container fields in `products`, `coupons`, and `orders`.
+  * `products.custom_fields` is now strictly aligned to BigCommerce docs as `array|null` of `{id, name, value}` objects. [#29](https://github.com/singer-io/tap-bigcommerce/pull/29)
+
+
 ## 1.3.1
   * Update tap to write metadata for root schema fields [#28](https://github.com/singer-io/tap-bigcommerce/pull/28)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-bigcommerce",
-    version="1.3.1",
+    version="2.0.0",
     description="Sync data from your BigCommerce Store",
     author="Chris Goddard",
     url="https://github.com/chrisgoddard",

--- a/tap_bigcommerce/schemas/coupons.json
+++ b/tap_bigcommerce/schemas/coupons.json
@@ -28,7 +28,7 @@
       "$ref": "type-string.json"
     },
     "applies_to": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "entity": {

--- a/tap_bigcommerce/schemas/orders.json
+++ b/tap_bigcommerce/schemas/orders.json
@@ -169,7 +169,7 @@
       "$ref": "type-string.json"
     },
     "billing_address": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
       	"first_name": {

--- a/tap_bigcommerce/schemas/products.json
+++ b/tap_bigcommerce/schemas/products.json
@@ -51,7 +51,7 @@
       "$ref": "type-string.json"
     },
     "categories": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "$ref": "type-integer.json"
       }
@@ -81,7 +81,7 @@
       "$ref": "type-boolean.json"
     },
     "related_products": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "$ref": "type-integer.json"
       }
@@ -209,21 +209,24 @@
       "$ref": "type-integer.json"
     },
     "custom_fields": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "$ref": "type-string.json"
-        },
-        "value": {
-          "$ref": "type-string.json"
-        },
-        "id": {
-          "$ref": "type-integer.json"
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "type-string.json"
+          },
+          "value": {
+            "$ref": "type-string.json"
+          },
+          "id": {
+            "$ref": "type-integer.json"
+          }
         }
       }
     },
     "bulk_pricing_rules": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31565

## ⚠️ Breaking Changes

This PR includes schema changes that may require downstream updates and is released as **v2.0.0**.

### What changed
- `products.custom_fields` is now strictly typed as `["array", "null"]` with object items (`name`, `value`, `id`).
- Several previously non-nullable container fields were updated to allow `null` to match API behavior:
  - `products.categories`
  - `products.related_products`
  - `coupons.applies_to`
  - `orders.billing_address`
  - `products.bulk_pricing_rules`

### Why this is breaking
- Pipelines that assumed a different shape for `products.custom_fields` (for example, object/non-array handling) may fail validation or transformation after upgrade.
- Strict schema-based loaders/models may need updates to reflect these type constraints.

### Action required
- Review downstream models/transformations for `products.custom_fields` and ensure they handle only array-or-null.
- Confirm warehouse/table definitions and dbt models accept nullable values for the updated fields above.
- Re-run discovery and refresh catalog/schema artifacts before next sync.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
